### PR TITLE
HOTFIX: Add Missing Project Metadata for PyPi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,20 @@ jobs:
         run: pipx install hatch
       - name: Run Hatch CI
         run: hatch run ci
-  # windows:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: |
-  #           3.10
-  #           3.11
-  #           3.12
-  #     - name: Install Hatch
-  #       run: pipx install hatch
-  #     - name: Run Hatch CI
-  #       run: hatch run ci
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.10
+            3.11
+            3.12
+      - name: Install Hatch
+        run: pipx install hatch
+      - name: Run Hatch CI
+        run: hatch run ci
   mac:
     runs-on: macos-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,43 @@ build-backend = "hatchling.build"
 [project]
 name = "grammlog"
 dynamic = ["version"]
-description = "GrammAcc's Structured Logging"
-authors = [{name = "GrammAcc"}]
-maintainers = [{name = "GrammAcc"}]
+description = "Structured logging to JSONL with support for asynchronous logging via asyncio"
+authors = [{ name = "GrammAcc" }]
+maintainers = [{ name = "GrammAcc" }]
 readme = "README.md"
+# Corresponds to the License-Expression used to display the license on the pypi page.
+license = "MIT"
+# Indicates the actual license file that should be included in the sdist.
+# Hatch will automatically include a file named "LICENSE", but explicit is better
+# than implicit... especially when lawyers are involved.
+license-files = { paths = ["LICENSE"] }
 requires-python = ">=3.10"
+keywords = ["logging", "structured-logging", "json-logging", "asyncio"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: File Formats :: JSON",
+    "Topic :: System :: Logging",
+    "Topic :: Utilities",
+    "Typing :: Typed",
+]
 
+[project.urls]
+homepage = "https://github.com/GrammAcc/grammlog"
+bug_tracker = "https://github.com/GrammAcc/grammlog/issues"
+documentation = "https://grammacc.github.io/grammlog"
+repository = "https://github.com/GrammAcc/grammlog"
 
 [project.optional-dependencies]
 dev = ["hatch"]
 
+
 [tool.hatch.version]
-path = "src/grammlog.py"
+path = "src/grammlog/__init__.py"
 
 
 [tool.hatch.build]
@@ -26,44 +51,28 @@ include = ["py.typed"]
 
 [tool.hatch.build.targets.sdist]
 include = ["src"]
+# Hatch doesn't support 2.4 yet.
+core-metadata-version = "2.3"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/grammlog.py"]
+packages = ["src/grammlog"]
+# Hatch doesn't support 2.4 yet.
+core-metadata-version = "2.3"
 
 
 [tool.hatch.envs.default]
 python = "3.12"
-dependencies = [
-    "pytest",
-    "pytest-cov",
-    # See: https://github.com/pytest-dev/pytest-asyncio/issues/706
-    "pytest-asyncio==0.21.2",
-    "black",
-    "flake8",
-    "isort",
-    "mypy",
-]
-
-[[tool.hatch.envs.default.matrix]]
-python = ["3.10", "3.11", "3.12"]
-
+dependencies = ["black", "flake8", "isort", "mypy"]
 
 [tool.hatch.envs.default.scripts]
-
-typecheck = "mypy src/grammlog.py"
-format = [
-    "isort --atomic .",
-    "black .",
-]
+typecheck = "mypy -p grammlog"
+format = ["isort --atomic .", "black ."]
 lint = "flake8 src test documentation"
-test = "pytest {args}"
-cov = "pytest --cov-config=pyproject.toml --cov-report html:htmlcov --cov=grammlog"
-doctest = [
-    "python -m doctest src/grammlog.py",
-    "python -m doctest README.md",
-]
+test = "hatch run +py=3.12 test:all {args}"
+cov = "hatch run test:cov"
+doctest = ["python -m doctest src/grammlog.py", "python -m doctest README.md"]
 ci = [
-    "hatch run test",
+    "hatch run test:all",
     "- hatch run cov",
     "hatch run doctest",
     "hatch run typecheck",
@@ -71,7 +80,7 @@ ci = [
 ]
 all = [
     "hatch run format",
-    "- hatch run test",
+    "- hatch run test:all",
     "- hatch run cov",
     "- hatch run doctest",
     "- hatch run typecheck",
@@ -79,13 +88,26 @@ all = [
 ]
 
 
+[tool.hatch.envs.test]
+description = "Test suite"
+dependencies = [
+    "pytest",
+    "pytest-cov",
+    # See: https://github.com/pytest-dev/pytest-asyncio/issues/706
+    "pytest-asyncio==0.21.2",
+]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.test.scripts]
+all = "pytest {args}"
+cov = "pytest --cov-config=pyproject.toml --cov-report html:htmlcov --cov=grammlog"
+
 
 [tool.hatch.envs.docs]
 description = "Documentation generation and utilities"
-dependencies = [
-    "pdoc",
-]
-
+dependencies = ["pdoc"]
 
 [tool.hatch.envs.docs.scripts]
 build = [
@@ -96,10 +118,15 @@ serve = "python documentation/serve.py"
 
 
 [tool.pytest.ini_options]
-log_file="testsuite.log"
-log_file_level="WARNING"
+log_file = "testsuite.log"
+log_file_level = "WARNING"
 addopts = "--import-mode=importlib --show-capture=no"
 asyncio_mode = "auto"
+
+
+[tool.mypy]
+check_untyped_defs = true
+
 
 [tool.coverage.run]
 branch = true
@@ -122,8 +149,6 @@ profile = "black"
 skip_gitignore = true
 force_grid_wrap = 2
 
-[tool.mypy]
-check_untyped_defs = true
 
 [tool.black]
 line-length = 100

--- a/src/grammlog/__init__.py
+++ b/src/grammlog/__init__.py
@@ -401,6 +401,12 @@ def _ensure_serializable(payload: dict[str, Any]) -> dict[str, str | dict]:
     # This is recursive, so it could fail if the provided dict is deeply nested.
     # This should only happen if the application exposes logging to user-input and
     # allows a user to construct a malicious payload.
+
+    # TODO: There is a bug in this implementation.
+    # It currently calls `str` on *all* values in the payload when json serialization fails, but
+    # it should only call `str` on values that are not serializable.
+    # This can cause problems when parsing the logged data in other environments if an integer gets
+    # serialized as a string for example.
     return {
         k: (_ensure_serializable(v) if isinstance(v, dict) else str(v)) for k, v in payload.items()
     }

--- a/src/grammlog/__init__.py
+++ b/src/grammlog/__init__.py
@@ -217,7 +217,7 @@ from typing import (
     Callable,
 )
 
-__VERSION__ = "1.0.0"
+__VERSION__ = "1.0.1"
 
 
 _string_to_log_level_map = {

--- a/test/env_test.py
+++ b/test/env_test.py
@@ -1,6 +1,7 @@
 import os
 import os.path
 import random
+import string
 from pathlib import Path
 
 import grammlog
@@ -9,10 +10,11 @@ import grammlog
 def test_log_level_override(fixt_default_logger):
     """Ensure that the DEFAULT_GRAMMLOG_LEVEL can be overriden with the GRAMMLOG_LEVEL env var."""
 
+    print("from the test suite")
     grammlog.debug(fixt_default_logger, "test message")
     assert os.path.getsize("logs/default.log") == 0
     os.environ["GRAMMLOG_LEVEL"] = "DEBUG"
-    rand_name = str(random.randbytes(10))
+    rand_name = "".join([random.choice(string.ascii_letters) for _ in range(8)])
     new_logger = grammlog.make_logger(rand_name)
     grammlog.debug(new_logger, "test message")
     data = Path(f"logs/{rand_name}.log").read_text()


### PR DESCRIPTION
I added the missing metadata to pyproject.toml and fixed the build so that the py.typed marker would be included in the distribution.

See child commit messages for details.